### PR TITLE
Ecoli updates

### DIFF
--- a/R/assessEcoli.r
+++ b/R/assessEcoli.r
@@ -43,6 +43,8 @@ assessEColi <- function(data, rec_season = TRUE, SeasonStartDate="05-01", Season
   # Read in data
   data_raw = data
   
+  ecoli_assessments$raw_data = data
+  
   # Geometric mean function
   gmean <- function(x){exp(mean(log(x)))}
   
@@ -50,7 +52,7 @@ assessEColi <- function(data, rec_season = TRUE, SeasonStartDate="05-01", Season
   uses_stds <- unique(data_raw[c("BeneficialUse","CriterionLabel","NumericCriterion")])
   
   # Remove duplicates from data
-  data_raw <- data_raw[,!names(data_raw)%in%c("AsmntAggPeriod","AsmntAggPeriodUnit","AsmntAggFun","CriterionLabel","NumericCriterion")]
+  data_raw <- data_raw[,!names(data_raw)%in%c("ActivityIdentifier","AsmntAggPeriod","AsmntAggPeriodUnit","AsmntAggFun","CriterionLabel","NumericCriterion")]
   data_raw <- unique(data_raw)
   
   # Convert dates to R dates
@@ -168,7 +170,7 @@ assessEColi <- function(data, rec_season = TRUE, SeasonStartDate="05-01", Season
       out$SampleCount = length(x$ActivityStartDate)
       geomean <- gmean(x$IR_Value)
       if(out$SampleCount<10){
-        out$IR_Cat = ifelse(geomean>stdcrit,"IDEX","IDNE")
+        out$IR_Cat = ifelse(geomean>stdcrit,"IDEX","FS")
       }else{
         out$IR_Cat = ifelse(geomean>stdcrit,"NS","FS")
       }

--- a/R/assessEcoli.r
+++ b/R/assessEcoli.r
@@ -54,7 +54,7 @@ assessEColi <- function(data, rec_season = TRUE, SeasonStartDate="05-01", Season
   data_raw <- unique(data_raw)
   
   # Convert dates to R dates
-  data_raw$ActivityStartDate=as.Date(data_raw$ActivityStartDate,format='%m/%d/%Y')
+  data_raw$ActivityStartDate=as.Date(data_raw$ActivityStartDate,format='%Y-%m-%d')
   
   # Create year column for scenario calculations
   data_raw$Year=lubridate::year(data_raw$ActivityStartDate)

--- a/R/assessEcoli.r
+++ b/R/assessEcoli.r
@@ -85,7 +85,7 @@ assessEColi <- function(data, rec_season = TRUE, SeasonStartDate="05-01", Season
   
   # Aggregate to daily values.
   daily_agg=aggregate(IR_Value~IR_MLID+BeneficialUse+ActivityStartDate,data=data_rec,FUN=function(x){exp(mean(log(x)))})
-  data_processed <- merge(daily_agg,unique(data_rec[,!names(data_rec)%in%c("ActivityStartTime.Time")]), all.x=TRUE)
+  data_processed <- merge(daily_agg,unique(data_rec[,!names(data_rec)%in%c("ActivityStartTime.Time","IR_Value")]), all.x=TRUE)
   ecoli_assessments$assessed_data = data_processed
 
   # maxSamps48hr function - counts the maximum number of samples collected over the rec season that were not collected within 48 hours of another sample(s).


### PR DESCRIPTION
Made a few slight changes to assessEcoli, including making sure the site-param-uses "Not Assessed" show up somewhere in a roll up for easy capture later (if needed). Also, specified columns being merged to daily values for two reasons (1) ensure no replicate-specific metadata would mess with merges in the function and (2) create output suitable for use in assessment dashboard app.